### PR TITLE
Need to clear out the histogram every report via @freeformz

### DIFF
--- a/librato.go
+++ b/librato.go
@@ -150,6 +150,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 					}
 				}
 				snapshot.Gauges = append(snapshot.Gauges, gauges...)
+				s.Clear()
 			}
 		case metrics.Meter:
 			measurement[Name] = name


### PR DESCRIPTION
The problem manifested because we  were doing load testing. If you do 10K requests, and then stop, and report only 1 request / second, you basically can't clear out the past percentiles. It will look like the metrics never moves at all
